### PR TITLE
Update address.rs

### DIFF
--- a/soroban-sdk/src/address.rs
+++ b/soroban-sdk/src/address.rs
@@ -262,7 +262,7 @@ impl Address {
     /// ### Panics
     ///
     /// If Address is not a contract ID.
-    pub(crate) fn contract_id(&self) -> BytesN<32> {
+    pub fn contract_id(&self) -> BytesN<32> {
         match self.try_contract_id() {
             Some(contract_id) => contract_id,
             None => panic!("Address is not a Contract ID"),


### PR DESCRIPTION
### What

Make `contract_id` of `Address` public.

### Why

The thing is, I couldn't find a way of persisting an Address in the storage. The point is to be able to store the address as `Val` (or anything storable) so it can be saved in the storage and then properly read from the storage.

We can do 
```
Address::from_contract_id(&BytesN::from_array(&env, &bytes));
```
to recreate `Address` from what we stored but it doesn't work the other way. I discovered I can do this:
```
let addr: Address = ... // some address we want to store
let storable_addr = addr.contract_id().to_array(); // so storable_addr would be [u8; 32]
```
the problem is, `contract_id` is private (I mean crate public, still innaccessible).

Is there any reason it could not be exposed as public?
Is there any other way to store the address in the storage?

Thanks!

### Known limitations

N/A
